### PR TITLE
feat(all): upgrade to `rxjs@6.2.0`

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "aurelia-framework": "^1.2.0",
     "aurelia-logging": "^1.4.0",
     "aurelia-pal": "^1.8.0",
-    "rxjs": "^5.5.10"
+    "rxjs": "^6.2.0"
   },
   "devDependencies": {
     "@types/jest": "^21.1.10",

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -1,6 +1,5 @@
 import { Container } from "aurelia-dependency-injection";
-import { Observable } from "rxjs/Observable";
-import { Subscription } from "rxjs/Subscription";
+import { Observable, Subscription } from "rxjs";
 
 import { Store } from "./store";
 
@@ -44,15 +43,17 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
     target.prototype[typeof settings === "object" && settings.setup ? settings.setup : "bind"] = function () {
       const source = getSource();
 
+      if (typeof settings == "object" &&
+        typeof settings.onChanged === "string" &&
+        !(settings.onChanged in this)) {
+        throw new Error("Provided onChanged handler does not exist on target VM");
+      }
+
       this._stateSubscription = source.subscribe(state => {
         // call onChanged first so that the handler has also access to the previous state
         if (typeof settings == "object" &&
           typeof settings.onChanged === "string") {
-          if (!(settings.onChanged in this)) {
-            throw new Error("Provided onChanged handler does not exist on target VM")
-          } else {
-            this[settings.onChanged](state);
-          }
+          this[settings.onChanged](state);
         }
 
         if (typeof settings === "object" && settings.target) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -1,5 +1,4 @@
-import { Observable } from "rxjs/Observable";
-import { BehaviorSubject } from "rxjs/BehaviorSubject";
+import { BehaviorSubject, Observable } from "rxjs";
 
 import {
   autoinject,

--- a/src/test-helpers.ts
+++ b/src/test-helpers.ts
@@ -1,6 +1,4 @@
-import "rxjs/add/operator/skip";
-import "rxjs/add/operator/take";
-import "rxjs/add/operator/delay";
+import { delay, skip, take } from "rxjs/operators";
 
 import { Store } from "./store";
 
@@ -37,11 +35,18 @@ export async function executeSteps<T>(store: Store<T>, shouldLogResults: boolean
     let currentStep = 0;
 
     steps.slice(0, -1).forEach((step) => {
-      store.state.skip(currentStep).take(1).delay(0).subscribe(tryStep(logStep(step, currentStep), reject));
+      store.state.pipe(
+        skip(currentStep),
+        take(1),
+        delay(0)
+      ).subscribe(tryStep(logStep(step, currentStep), reject));
       currentStep++;
     });
 
-    store.state.skip(currentStep).take(1).subscribe(
+    store.state.pipe(
+      skip(currentStep),
+      take(1)
+    ).subscribe(
       lastStep(tryStep(logStep(steps[steps.length - 1], currentStep), reject), resolve));
   });
 }

--- a/test/unit/decorator.spec.ts
+++ b/test/unit/decorator.spec.ts
@@ -1,9 +1,9 @@
 import { Container } from "aurelia-framework";
-import "rxjs/add/operator/pluck";
+import { Subscription } from "rxjs";
+import { pluck } from "rxjs/operators";
 
 import { Store } from "../../src/store";
 import { connectTo } from "../../src/decorator";
-import { Subscription } from "rxjs/Subscription";
 
 interface DemoState {
   foo: string;
@@ -40,7 +40,7 @@ describe("using decorators", () => {
   it("should be possible to provide a state selector", () => {
     const { store, initialState } = arrange();
 
-    @connectTo<DemoState>((store) => store.state.pluck("bar"))
+    @connectTo<DemoState>((store) => store.state.pipe(pluck("bar")))
     class DemoStoreConsumer {
       state: DemoState;
     }
@@ -58,7 +58,7 @@ describe("using decorators", () => {
       const { store, initialState } = arrange();
 
       @connectTo<DemoState>({
-        selector: (store) => store.state.pluck("bar")
+        selector: (store) => store.state.pipe(pluck("bar"))
       })
       class DemoStoreConsumer {
         state: DemoState;
@@ -94,7 +94,7 @@ describe("using decorators", () => {
       const { store, initialState } = arrange();
 
       @connectTo<DemoState>({
-        selector: (store) => store.state.pluck("bar"),
+        selector: (store) => store.state.pipe(pluck("bar")),
         target: "foo"
       })
       class DemoStoreConsumer {

--- a/test/unit/dispatchify.spec.ts
+++ b/test/unit/dispatchify.spec.ts
@@ -1,5 +1,5 @@
 import { Container } from "aurelia-dependency-injection";
-import "rxjs/add/operator/skip";
+import { skip } from "rxjs/operators";
 
 import { dispatchify, Store } from "../../src/store";
 import { createTestStore, testState } from "./helpers";
@@ -17,7 +17,9 @@ describe("dispatchify", () => {
 
     dispatchify(fakeAction)("A", "B");
 
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state.foo).toEqual("AB");
       done();
     });
@@ -52,7 +54,9 @@ describe("dispatchify", () => {
 
     dispatchify(fakeActionRegisteredName)("A", "B");
 
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state.foo).toEqual("AB");
       done();
     });

--- a/test/unit/middleware.spec.ts
+++ b/test/unit/middleware.spec.ts
@@ -1,6 +1,5 @@
 import { PLATFORM } from "aurelia-pal";
-import "rxjs/add/operator/skip";
-import "rxjs/add/operator/take";
+import { skip, take } from "rxjs/operators";
 
 import {
   MiddlewarePlacement,
@@ -196,7 +195,10 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).take(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1),
+        take(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(2);
         done();
       });
@@ -218,7 +220,10 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).take(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1),
+        take(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1000);
         done();
       });
@@ -238,7 +243,10 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).take(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1),
+        take(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1000);
         done();
       });
@@ -258,7 +266,10 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).take(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1),
+        take(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1);
         done();
       });
@@ -275,7 +286,9 @@ describe("middlewares", () => {
     store.registerAction("IncrementAction", incrementAction);
     store.dispatch(incrementAction);
 
-    store.state.skip(1).subscribe((state: TestState) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state: TestState) => {
       expect(state.counter).toEqual(2);
       done();
     });
@@ -371,7 +384,10 @@ describe("middlewares", () => {
     store.registerAction("IncrementAction", incrementAction);
     store.dispatch(incrementAction);
 
-    store.state.skip(1).take(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1),
+      take(1)
+    ).subscribe((state) => {
       expect(state.counter).toEqual(14);
       done();
     });
@@ -409,7 +425,10 @@ describe("middlewares", () => {
     store.registerAction("Demo", demoAction);
     store.dispatch(demoAction);
 
-    store.state.skip(1).take(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1),
+      take(1)
+    ).subscribe((state) => {
       expect(state.values).toEqual(["Demo", ...new Array(26).fill("").map((_, idx) => String.fromCharCode(65 + idx))]);
       done();
     });
@@ -426,7 +445,9 @@ describe("middlewares", () => {
     store.registerAction("IncrementAction", incrementAction);
     store.dispatch(incrementAction);
 
-    store.state.skip(1).subscribe(() => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe(() => {
       expect(global.console.log).toHaveBeenCalled();
       (global.console.log as any).mockReset();
       (global.console.log as any).mockRestore();
@@ -445,7 +466,9 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(2);
         expect(global.console.log).toHaveBeenCalled();
 
@@ -465,7 +488,9 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(2);
         expect(global.console.warn).toHaveBeenCalled();
 
@@ -494,7 +519,9 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(2);
         expect(PLATFORM.global.localStorage.getItem("aurelia-store-state")).toBe(JSON.stringify(state));
         done();
@@ -519,7 +546,9 @@ describe("middlewares", () => {
       store.registerAction("IncrementAction", incrementAction);
       store.dispatch(incrementAction);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(2);
         expect(PLATFORM.global.localStorage.getItem(key)).toBe(JSON.stringify(state));
         done();
@@ -542,7 +571,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1000);
         done();
       });
@@ -565,7 +596,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1000);
         done();
       });
@@ -580,7 +613,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1);
         done();
       });
@@ -599,7 +634,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1);
         done();
       });
@@ -621,7 +658,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.present.counter).toEqual(1000);
         done();
       });
@@ -640,7 +679,9 @@ describe("middlewares", () => {
       store.registerAction("Rehydrate", rehydrateFromLocalStorage);
       store.dispatch(rehydrateFromLocalStorage);
 
-      store.state.skip(1).subscribe((state) => {
+      store.state.pipe(
+        skip(1)
+      ).subscribe((state) => {
         expect(state.counter).toEqual(1);
         done();
       });

--- a/test/unit/redux-devtools.spec.ts
+++ b/test/unit/redux-devtools.spec.ts
@@ -1,5 +1,4 @@
-import "rxjs/add/operator/skip";
-import "rxjs/add/operator/delay";
+import { skip, delay } from "rxjs/operators";
 
 import {
   createTestStore,
@@ -20,10 +19,10 @@ describe("redux devtools", () => {
     store.registerAction("FakeAction", fakeAction);
     store.dispatch(fakeAction);
 
-    store.state
-      .skip(1)
-      .delay(1)
-      .subscribe(() => {
+    store.state.pipe(
+      skip(1),
+      delay(1)
+    ).subscribe(() => {
       expect(spy).toHaveBeenCalled();
 
       spy.mockReset();

--- a/test/unit/store.spec.ts
+++ b/test/unit/store.spec.ts
@@ -1,5 +1,5 @@
 import { Container } from "aurelia-framework";
-import "rxjs/add/operator/skip";
+import { skip } from "rxjs/operators";
 
 import {
   Store,
@@ -105,7 +105,9 @@ describe("store", () => {
     store.registerAction("FakeAction", fakeAction as any);
     store.dispatch(fakeAction, "A", "B");
 
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state.foo).toEqual("AB");
       done();
     });
@@ -121,7 +123,9 @@ describe("store", () => {
     store.registerAction("FakeAction", fakeAction);
     store.dispatch(fakeAction);
 
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state).toEqual(modifiedState);
       done();
     });
@@ -137,7 +141,9 @@ describe("store", () => {
     store.dispatch(fakeActionRegisteredName);
 
     // since the async action is coming at a later time we need to skip the initial state
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state).toEqual(modifiedState);
       done();
     });
@@ -152,7 +158,9 @@ describe("store", () => {
     store.dispatch(fakeAction);
 
     // since the async action is coming at a later time we need to skip the initial state
-    store.state.skip(1).subscribe((state) => {
+    store.state.pipe(
+      skip(1)
+    ).subscribe((state) => {
       expect(state).toEqual(modifiedState);
       done();
     });
@@ -169,7 +177,9 @@ describe("store", () => {
     store.dispatch(actionA);
     store.dispatch(actionB);
 
-    store.state.skip(2).subscribe((state) => {
+    store.state.pipe(
+      skip(2)
+    ).subscribe((state) => {
       expect(state.foo).toEqual("barAB");
       done();
     });

--- a/test/unit/undo.spec.ts
+++ b/test/unit/undo.spec.ts
@@ -1,5 +1,3 @@
-import "rxjs/add/operator/skip";
-
 import {
   createStoreWithStateAndOptions,
   createUndoableTestStore,


### PR DESCRIPTION
Upgrade `aurelia-store` to use `rxjs@6.2.0`

**Changes**
- imports now are from `rxjs` for observables and `rxjs/operators` for operators
- removed all chained rxjs operators and refactor to use `pipe`
- decorator `connectTo` handler check for `onChanged` moved ouside subscription due to changes in how `rxjs` handles errors in async contexts

For more info about the migration, please visit the Migration Guideline over at rxjs
https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md