### PR TITLE
Doc: textual fixes

### DIFF
--- a/doc/article/en-US/aurelia-store-plugin.md
+++ b/doc/article/en-US/aurelia-store-plugin.md
@@ -5,7 +5,7 @@ author: Vildan Softic (http://github.com/zewa666)
 ---
 ## Introduction
 
-This article covers the Store plugin for Aurelia. It is built on top of two core features of [RxJS](http://reactivex.io/rxjs/), namely Observables and the BehaviorSubject. You're don't have to delve into the reactive universe - in fact, you'll barely notice it at the beginning. But you can certainly benefit from having some knowledge about RxJS in order to use it wisely.
+This article covers the Store plugin for Aurelia. It is built on top of two core features of [RxJS](http://reactivex.io/rxjs/), namely Observables and the BehaviorSubject. You don't have to delve into the reactive universe - in fact, you'll barely notice it at the beginning. But you can certainly benefit from having some knowledge about RxJS in order to use it wisely.
 
 Various examples, demonstrating individual pieces of the plugin, can be found in the [samples repository](https://github.com/zewa666/aurelia-store-examples).
 

--- a/doc/article/en-US/aurelia-store-plugin.md
+++ b/doc/article/en-US/aurelia-store-plugin.md
@@ -5,13 +5,13 @@ author: Vildan Softic (http://github.com/zewa666)
 ---
 ## Introduction
 
-This article covers the Store plugin for Aurelia. It is built on top of two core features of [RxJS](http://reactivex.io/rxjs/), namely Observables and the BehaviorSubject. You're not forced to delve into the reactive universe, in fact, you'll barely notice it at the begin but certainly can benefit a lot when using it wisely.
+This article covers the Store plugin for Aurelia. It is built on top of two core features of [RxJS](http://reactivex.io/rxjs/), namely Observables and the BehaviorSubject. You're don't have to delve into the reactive universe - in fact, you'll barely notice it at the beginning. But you can certainly benefit from having some knowledge about RxJS in order to use it wisely.
 
 Various examples, demonstrating individual pieces of the plugin, can be found in the [samples repository](https://github.com/zewa666/aurelia-store-examples).
 
 ### Reasons for state management
 
-Currently, a lot of modern development approaches leverage a single store, which acts as a central basis of your app. The idea is that it holds all data, that makes up your application. The content of your store is your application's state. If you will, the app state is a snapshot of data at a specific moment in time. You modify that by using Actions, which are the only way to manipulate the global state, and create the next app state.
+A lot of modern development approaches leverage a single store, which acts as a central basis of your app. The idea is that it holds all data that makes up your application. The content of your store is your application's state. If you will, the app state is a snapshot of all data at a specific moment in time. You modify that by using Actions, which are the only way to manipulate the global state, and create the next app state.
 
 Contrast this to classic service-oriented approaches, where data is split amongst several service entities. What turns out to be a simpler approach, in the beginning, especially combined with a powerful IoC Container, can become a problem once the size of the app grows. Not only do you start to get increased complexity and inter-dependency of your services, but keeping track of who modified what and how to notify every component about a change can become tricky.
 
@@ -19,19 +19,19 @@ Leveraging a single store approach, there is only one source of truth for your d
 
 ### Why is RxJS used for this plugin?
 
-As mentioned in the intro this plugin uses RxJS as a foundation. The main idea is having a [BehaviorSubject](http://reactivex.io/rxjs/manual/overview.html#behaviorsubject) `store._state` which will store the current state, at the begin the initial state, and emit new states as they come. Since having access to the BehaviorSubject would allow consumers to directly emit the `next` value, instead of a front-facing `state` property, being an Observable which connects to the BehaviorSubject, is exposed. This way consumers only have access to streamed values but cannot directly manipulate the streaming queue.
+As mentioned in the intro this plugin uses RxJS as a foundation. The main idea is having a [BehaviorSubject](http://reactivex.io/rxjs/manual/overview.html#behaviorsubject) `store._state` which will store the current state. It starts with some initial state and emits new states as they come. Since having access to the BehaviorSubject would allow consumers to directly emit the `next` value, instead of a front-facing `state` property, being an Observable which connects to the BehaviorSubject, is exposed. This way consumers only have access to streamed values but cannot directly manipulate the streaming queue.
 
 But besides these core features, RxJS itself can be described as [*Lodash/Underscore for events*](http://reactivex.io/rxjs/manual/overview.html#introduction). As such all of the operators and objects can be used to manipulate the state in whatever way necessary. As an example [pluck](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-pluck) can be used to pierce into a sub-section of the state, whereas methods like [skip]()http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-skip and [take](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-take) are great ways to unit test the stream of states over time.
 
 The main reason for using RxJS though is that observables are delivered over time. This promotes a reactive approach to how you'd design your application. Instead of pursuing an imperative approach like **a click on button A** should **trigger a re-rendering on component B**, we follow an [Observer Pattern](https://en.wikipedia.org/wiki/Observer_pattern) where **component B observes a global state** and **acts on changes**, which are **triggered through actions by button A**.
 
-Broken down on the concepts of Aurelia, as depicted in the following chart, this means that a ViewModel subscribes to the single store and sets up a state subscription. The view directly binds to properties of the state. Actions can be dispatched and trigger the next state emit. Now the initial subscription receives the next state and changes the bound variable, Aurelia automatically figures out what changed and triggers a re-render. The next dispatch will then trigger the next cycle and so on. This way the system behaves in a cyclic, reactive way and sees state changes as requests for a re-rendering.
+Broken down to the concepts of Aurelia, as depicted in the following chart, this means that a ViewModel subscribes to the single store and sets up a state subscription. The view directly binds to properties of the state. Actions can be dispatched and trigger the next state emit. Now the initial subscription receives the next state and changes the bound variable, Aurelia automatically figures out what changed and triggers a re-render. The next dispatch will then trigger the next cycle and so on. This way the system behaves in a cyclic, reactive way and sees state changes as requests for a re-rendering.
 
 ![Chart workflow](images/chart_store_workflow.png)
 
-A fundamental benefit of that approach is, that you as a developer do not need to think of signaling individual components about changes, but rather they will all listen and react to changes by themselves if the respective part of the state gets modified. Think of it as an event dispatch, where multiple recipients can listen for and perform changes but with the benefit of a formalized global state. As such, all you need to focus on is the state and the rest will be handled automatically.
+A fundamental benefit of that approach is that you as a developer do not need to think of signaling individual components about changes, but rather they will all listen and react to changes by themselves if the respective part of the state gets modified. Think of it as an event dispatch, where multiple recipients can listen for and perform changes but with the benefit of a formalized global state. As such, all you need to focus on is the state and the rest will be handled automatically.
 
-Another benefit is the async nature of the subscription. No matter whether the action is a synchronous operation, like changing the title of your page, an Ajax request to fetch the latest products or a long-running web-socket for your next chat application. Whenever you dispatch the next action, listeners will react to these changes.
+Another benefit is the async nature of the subscription. No matter whether the action is a synchronous operation, like changing the title of your page, an Ajax request to fetch the latest products or a long-running web-socket for your next chat application: whenever you dispatch the next action, listeners will react to these changes.
 
 ## Getting Started
 
@@ -74,13 +74,13 @@ alternatively, you can manually add these dependencies to your vendor bundle:
 ## Granular (patched) RxJS imports
 
 > Info
-> With the recent release of RxJS v.6 quite a lot has changed. There are new ways to import dependencies and ways to keep compatibility with previous API versions. Take a look at the [following upgrade instructions](https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md) for further details. In case you're using a classic Require.js based Aurelia CLI project setup, make sure to [configure rxjs-compat](https://www.npmjs.com/package/rxjs-compat) in aurelia.json as a dependency and use it as the main include file. If you do on the other already use the newest APIs you'll have to adjust your `aurelia.json` or do a fresh new `au import aurelia-store` to get the rxjs dependencies properly auto-setup.
+> With the recent release of RxJS v.6 quite a lot has changed. There are new ways to import dependencies and ways to keep compatibility with previous API versions. Take a look at the [following upgrade instructions](https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md) for further details. In case you're using a classic Require.js based Aurelia CLI project setup, make sure to [configure rxjs-compat](https://www.npmjs.com/package/rxjs-compat) in aurelia.json as a dependency and use it as the main include file. If, on the other hand, you already use the newest APIs you'll have to adjust your `aurelia.json` or do a fresh new `au import aurelia-store` to get the rxjs dependencies to properly do an auto-setup.
 
 **This section is only valid for RxJS versions less than or equal to 5.x.x**
 
-Looking at the above dependency configuration for Aurelia CLI you'll note the use of `"main": false`, which tells the loader not to use any default file and not start importing things right away. The reason for this is that importing the whole RxJS library would net result in additional ~250kb for your app, where you'd most of the time need only a minimum subset. Patched imports enable to bundle only things directly referenced.
+Looking at the above dependency configuration for Aurelia CLI you'll note the use of `"main": false`, which tells the loader not to use any default file and not start importing things right away. The reason for this is that importing the whole RxJS library would net result in additional ~250kb for your app, where you'd need only a minimum subset most of the time. Patched imports enable you to bundle only things directly referenced.
 
-What you need to make sure of when requesting features from RxJS though is that you do not import the full library itself anywhere. This applies to other bundlers such as Webpack as well. That can happen through one of the following statements:
+What you need to make sure of when requesting features from RxJS is that you do not import the full library itself. This applies to other bundlers such as Webpack as well. That can happen through one of the following statements:
 
 <code-listing heading="Imports triggering a full RxJS bundle">
   <source-code lang="TypeScript">
@@ -92,9 +92,9 @@ What you need to make sure of when requesting features from RxJS though is that 
   </source-code>
 </code-listing>
 
-So try to avoid these and instead only import operators and observable features as needed like in the following way:
+So try to avoid these and instead only import operators and observable features as needed, like this:
 
-<code-listing heading="Imports triggering a full RxJS bundle">
+<code-listing heading="Imports triggering only a partial RxJS bundle">
   <source-code lang="TypeScript">
     // RxJS v >= 6.x.x
     // Imports the Observable constructor, creation methods, types and schedulers
@@ -116,18 +116,18 @@ So try to avoid these and instead only import operators and observable features 
 </code-listing>
 
 > Info
-> Additional information and tips & tricks about size-sensitive bundling with Aurelia CLI can be found [here](http://pragmatic-coder.net/aurelia-cli-and-rxjs-size-sensitive-bundles/)
+> Additional information and tips & tricks about size-sensitive bundling with Aurelia CLI can be found [here](http://pragmatic-coder.net/aurelia-cli-and-rxjs-size-sensitive-bundles/).
 
 ## What is the State?
 
-A typical application consists of multiple components, which render various data. Besides actual data though, your components also contain the various statuses, like an active state for a toggle button, but also high-level states like the selected theme or current page.
-The contained component state is a good thing and should stay with the component, as long as only that single instance cares about it. The moment you reference the internal state from another component though, you're going to need a different approach like service classes. Another related topic is the inter-component communication where both services but also pub-sub mechanisms like the EventAggregator may be used.
+A typical application consists of multiple components, which render various data. Besides actual data though, your components also contain various statuses. An "active" status for a toggle button for example, but also high-level statuses like the selected theme or the current page.
+State that is contained within the component is a good thing, as long as only that single component instance cares about it. But the moment you reference that state from another component, you're going to need a way to communicate about that state, like service classes. Pub-sub mechanisms like the EventAggregator are another example of inter-component communication.
 
-In contrast to that, the Store plugin operates on a single overall application state. Think of it as a large object containing all the sub-states reflecting your applications condition at a specific moment in time. This state object needs only to contain serializable properties. With that you gain the benefit of having snapshots of your app, which allow all kinds of cool features like time-traveling, save/reload and so on.
+In contrast to that, the Store plugin operates on a single overall application state. Think of it as a large object containing all the sub-states reflecting your applications condition at a specific moment in time. This state object needs to only contain serializable properties. With that you gain the benefit of having snapshots of your app, which allow all kinds of cool features like time-traveling, save/reload and so on.
 
-How much you put into your state is up to you, but a good rule of thumb is that as soon as two different areas of your application consume the same data or affect component states you should store them.
+How much you put into your state is up to you, but a good rule of thumb is that as soon as two different areas of your application consume the same data or affect the same component state you should store them.
 
-Your app will typically start with a beginning state, called initial state, which later on is manipulated throughout the app's lifecycle. As mentioned it can be pretty much anything like shown in below example. Whether you prefer TypeScript or pure JavaScript is up to you, but having a typed state, allows for easier refactoring and better autocompletion support.
+Your app will typically start with an initial state, which is then manipulated throughout the app's lifecycle. As mentioned this state can be pretty much anything, like shown in the example below. Whether you prefer TypeScript or pure JavaScript is up to you, but having a typed state allows for easier refactoring and better autocompletion support.
 
 <code-listing heading="Defining the State entity and initialState">
   <source-code lang="TypeScript">
@@ -154,7 +154,7 @@ Your app will typically start with a beginning state, called initial state, whic
 
 ## Configuring your app
 
-In order to tell Aurelia how to use the plugin, we need to register it. This is done in your apps `main` file, specifically the `configure` method. We'll have to register the Store using our previously defined State entity:
+In order to tell Aurelia how to use the plugin, we need to register it. This is done in your app's `main` file, specifically the `configure` method. We'll have to register the Store using our previously defined State entity:
 
 <code-listing heading="Registering the plugin">
   <source-code lang="TypeScript">
@@ -199,7 +199,7 @@ With this done we're ready to consume our app state and dive into the world of s
 
 ## Subscribing to the stream of states
 
-As explained in the beginning, the Aurelia Store plugin provides a public observable called `state` which will stream the apps states over time. So in order to consume it, we first need to inject the store via dependency injection into the constructor. Next, inside the `bind` lifecycle method we are subscribing to the store's `state` property. Inside the *next-handler* we'll have the actually streamed state and may assign it to the components local state property. Last but not least let's not forget to dispose the subscription ones the component becomes unbound. This happens by calling the subscriptions `unsubscribe` method.
+As explained in the beginning, the Aurelia Store plugin provides a public observable called `state` which will stream the app's states over time. So in order to consume it, we first need to inject the store via dependency injection into the constructor. Next, inside the `bind` lifecycle method we are subscribing to the store's `state` property. Inside the subscription's *handler* we'll have the actually streamed state and may assign it to the component's local state property. And let's not forget to dispose of the subscription once the component becomes unbound. This happens by calling the subscription's `unsubscribe` method.
 
 <code-listing heading="Injecting the store and creating a subscription">
   <source-code lang="TypeScript">
@@ -255,7 +255,7 @@ As explained in the beginning, the Aurelia Store plugin provides a public observ
 </code-listing>
 
 > Info
-> Note that in the TypeScript version we didn't have to type-cast the state variable provided to the next handler since the initial store was injected using the `State` entity as a generic provider.
+> Note that in the TypeScript version we didn't have to type-cast the state variable provided to the subscription handler since the initial store was injected using the `State` entity as a generic provider.
 
 With that in place the state can be consumed as usual directly from within your template:
 
@@ -272,16 +272,16 @@ With that in place the state can be consumed as usual directly from within your 
   </source-code>
 </code-listing>
 
-Since you've subscribed to the state, every new one that arrives will again be assigned to the components `state` property and the UI automatically re-rendered, based on the details that changed.
+Since you've subscribed to the state, every new version of the state that arrives will again be assigned to the component's `state` property and the UI automatically re-rendered, based on the details that changed.
 
 ## Subscribing with the connectTo decorator
 
 In the previous section, you've seen how to manually bind to the state observable for full control.
 But instead of handling subscriptions and disposal of those by yourself, you may prefer to use the `connectTo` decorator.
-What it does is to connect your store's state automatically to a class property called `state`. It does so by overriding by default the
-`bind` and `unbind` life-cycle method for a proper setup and teardown of the state subscription, which will be stored in a property called `_stateSubscription`.
+What it does is to connect your store's state automatically to a class property called `state`. It does so by overriding the
+`bind` and `unbind` life-cycle methods for a proper setup and teardown of the state subscription, which will be stored in a property called `_stateSubscription`.
 
-Above ViewModel example could look the following using the connectTo decorator:
+The above ViewModel example could look like this using the `connectTo` decorator:
 
 <code-listing heading="Using the connectTo decorator">
   <source-code lang="TypeScript">
@@ -463,15 +463,14 @@ Next, let's find out how to produce state changes.
 ## What are actions?
 
 Actions are the primary way to create a new state. They are essentially functions which take the current state and optionally one or more arguments.
-Their job is to create the next state and return it. By doing so they should not mutate the passed in current state but instead use immutable functions to create
-either a proper clone. The reason for that is that each state represents a unique snapshot of your app in time. By modifying it, you'd alter the state and wouldn't be able to properly compare the old and new state. Further implications by that would be that advanced features such as time-traveling through states wouldn't work anymore.
+Their job is to create the next state and return it. By doing so they should not mutate the passed-in current state but instead use immutable functions to create a proper clone. The reason for that is that each state represents a unique snapshot of your app in time. By modifying it, you'd alter the state and wouldn't be able to properly compare the old and new state. It would also mean that advanced features such as time-traveling through states wouldn't work properly anymore.
 So keep in mind ... don't mutate your state.
 
 > Info
-> In case you're not a fan of functional approaches take a look at libraries like [Immer.js](https://github.com/mweststrate/immer), and the [Aurelia store example](https://github.com/zewa666/aurelia-store-examples#immer) using it, to act like you'd mutate the object but secretly get a proper clone.
+> In case you're not a fan of functional approaches take a look at libraries like [Immer.js](https://github.com/mweststrate/immer), and the [Aurelia store example](https://github.com/zewa666/aurelia-store-examples#immer) using it: this lets you act like you're mutating the state object but secretly you're getting a proper clone.
 
-Continuing with above framework example, an action to add an additional framework would look like the following.
-You create a shallow clone of the state by using Object.assign. By saying shallow it means that the actual `frameworks` array in the new state will just reference the original one. So in order to fix that we can use the array spread syntax plus the new `frameworkName` to create a fresh new array.
+Continuing with above framework example, let's say we want to make an action to add an additional framework to the list.
+You can create a "shallow" clone of the state by using `Object.assign`. By saying shallow we mean that the actual `frameworks` array in the new state object will just be a reference to the original one. So in order to fix that we can use the array spread syntax with the name of the new framework to create a fresh array.
 
 <code-listing heading="A simple action">
   <source-code lang="TypeScript">
@@ -494,7 +493,7 @@ You create a shallow clone of the state by using Object.assign. By saying shallo
   </source-code>
 </code-listing>
 
-Next, we need to register the created action with the store. That is done by calling the stores `registerAction` method. By doing so we can provide a name which will be used for all kinds of error-handlers, logs, and even Redux DevTools. As a second argument, we pass the action itself. 
+Next, we need to register the created action with the store. That is done by calling the store's `registerAction` method. By doing so we can provide a name which will be used for all kinds of error-handlers, logs, and even Redux DevTools. As a second argument, we pass the action itself.
 
 <code-listing heading="Registering an action">
   <source-code lang="TypeScript">
@@ -537,7 +536,7 @@ Next, we need to register the created action with the store. That is done by cal
   </source-code>
 </code-listing>
 
-You can unregister actions whenever needed by using the stores `unregisterAction` method
+You can unregister actions whenever needed by using the store's `unregisterAction` method
 
 <code-listing heading="Unregistering an action">
   <source-code lang="TypeScript">
@@ -577,9 +576,9 @@ You can unregister actions whenever needed by using the stores `unregisterAction
 
 ## Async actions
 
-Previously we mentioned that an action should return a state. What we didn't mention is that they are also able to return a promise which will eventually resolve with the new state.
+Previously we mentioned that an action should return a state. What we didn't mention is that actions can also return a promise which will eventually resolve with the new state.
 
-From above example, imagine we'd have to validate the given name, which happens in an async manner.
+From the above example, imagine we'd have to validate the given name, which happens in an async manner.
 
 <code-listing heading="An async action">
   <source-code lang="TypeScript">
@@ -631,12 +630,12 @@ From above example, imagine we'd have to validate the given name, which happens 
 </code-listing>
 
 > Info
-> You're not forced to use async/await but it's highly recommended to use it for better readability wherever you can
+> You dont't have to use async/await but it's highly recommended to use it for better readability whenever you can.
 
 ## Dispatching actions
 
 So far we've just created an action and registered it by several means. Now let's look at how we can actually execute one of them to trigger the next state change.
-We can use the store method `dispatch` to exactly do that. In below example, the function `dispatchDemo`, can be called with an argument `nextFramework`.
+We can use the store method `dispatch` to do exactly that. In the example below, the function `dispatchDemo` can be called with an argument `nextFramework`.
 Inside we call `store.dispatch`, passing it the action itself and all subsequent parameters required.
 Alternatively we can also provide the previously registered name instead.
 
@@ -693,21 +692,20 @@ Alternatively we can also provide the previously registered name instead.
   </source-code>
 </code-listing>
 
-Now keep in mind that an action might be async, or really any middleware is, you'll learn more about them later, as such if you're depending on the state being updated right after it, make sure to `await` the call to `dispatch`.
+Now keep in mind that an action might be async (really any middleware might be - you'll learn more about middleware later), and as such if you depend on the state being updated right after dispatching an action, make sure to `await` the call to `dispatch`.
 
-The choice whether you call by the actual actions function or it's previously registered name is up to you. It might
+The choice whether you dispatch using the actual action function or its previously registered name is up to you. It might
 be less work just forwarding a string. That way you don't need to import the action from wherever you want to dispatch
-it. On the other hand exactly this is a helpful mechanism to make sure your app survives a refactoring session. Imagine
-you'd rename the registration name and not all the places you're dispatching. A long debugging night might be just around the corner ;)
+it. On the other hand using the actual function is a helpful mechanism to make sure your app survives a refactoring session. Imagine you'd rename the action's name but forgot to update all the places that dispatch it. A long night of debugging might be just around the corner ;)
 
 > Info
-> Dispatching non-registered actions will result in an error
+> Dispatching non-registered actions will result in an error.
 
 ## Using the dispatchify higher order function
 
-Perhaps you don't want or can't obtain a reference to the store but still would like to dispatch your actions.
-This is especially useful if you don't want your child-elements to have any knowledge of the actual logic and just receive actions via attributes. Childs then can call this method directly via the template.
-In order to do so, you can leverage the higher order function `dispatchify`. What it does is returning a wrapped new function which will obtain the store by itself and forward the provided arguments directly to `store.dispatch`.
+Perhaps you don't want to or can't obtain a reference to the store, but you'd still like to dispatch your actions.
+This is especially useful if you don't want your child-elements to have any knowledge of the actual logic and just receive actions via attributes. Children can then call this method directly in the template.
+In order to do so, you can leverage the higher order function `dispatchify`. What it does is return a wrapped new function which will obtain the store by itself and forward the provided arguments directly to `store.dispatch`.
 
 <code-listing heading="Forwarding a dispatchable function as argument to child-elements">
   <source-code lang="TypeScript">
@@ -843,7 +841,7 @@ Since the whole concept of this plugin is to stream states over time, it makes s
   </source-code>
 </code-listing>
 
-Now when you subscribe to new state changes, instead of a simple State you'll get a StateHistory<State> object returned, which looks like the following:
+Now when you subscribe to new state changes, instead of a simple State you'll get a `StateHistory<State>` object returned, which looks like the following:
 
 ```typescript
 // aurelia-store -> history.ts
@@ -898,12 +896,12 @@ export interface StateHistory<T> {
 </code-listing>
 
 
-## Making our app history aware
+## Making our app history-aware
 
 Now keep in mind that every action will receive a `StateHistory<T>` as input and should return a new `StateHistory<T>`.
 You can use the `nextStateHistory` helper function to easily push your new state and create a proper StateHistory representation, which will simply move the currently present state to the past, place your provided one as the present and remove the future states.
 
-<code-listing heading="A StateHistory aware action">
+<code-listing heading="A StateHistory-aware action">
   <source-code lang="TypeScript">
     
     // app.ts
@@ -1091,18 +1089,18 @@ That means your past and future arrays can hold only a maximum of the provided `
 </code-listing>
 
 
-## Handling side effects with middlewares
+## Handling side-effects with middleware
 
-Aurelia Store uses a concept of middlewares to handle side-effects. Concept-wise they are similar to Express.js middlewares in that they allow to perform side-effects or manipulate request data. As such they are registered functions, which execute before or after each dispatched action.
+Aurelia Store uses a concept of middleware to handle side-effects. Conceptually they are similar to Express.js middlewares in that they allow to perform side-effects or manipulate request data. As such they are registered functions, which execute before or after each dispatched action.
 
-A middleware is similar to an action, with the difference that it may return void as well. Middlewares can be executed before the dispatched action, thus potentially manipulating the current state which will be passed to the action, or afterward, modifying the returned value from the action. If they don't return the previous value will be passed as input. Either way, the middleware reducer can be sync as well as async.
+A middleware is similar to an action, with the difference that it may return void as well. Middlewares can be executed before the dispatched action, thus potentially manipulating the current state which will be passed to the action, or afterward, modifying the returned value from the action. If they don't return anything the previous value will be passed as output. Either way, the middleware can be sync as well as async.
 
 > Warning
 > As soon as you have one async middleware registered, essentially all action dispatches will be async as well.
 
 ![Chart workflow](images/middlewares.png)
 
-Middlewares are registered using `store.registerMiddleware` with the middlewares function and the placement `before` or `after`. Unregistration can be done using `store.unregisterMiddleware`
+Middlewares are registered using `store.registerMiddleware` with the middleware's function and the placement `before` or `after`. Unregistration can be done using `store.unregisterMiddleware`
 
 <code-listing heading="Registering a middleware">
   <source-code lang="TypeScript">
@@ -1127,7 +1125,7 @@ Middlewares are registered using `store.registerMiddleware` with the middlewares
   </source-code>
 </code-listing>
 
-> You can call the `store.registerMiddleware` function whenever you want. This means middlewares don't have to be defined upfront at the apps configuration time but whenever needed. Same applies to `store.unregisterMiddleware`.
+> You can call the `store.registerMiddleware` function whenever you want. This means middlewares don't have to be defined upfront at the apps configuration time but whenever needed. The same applies to `store.unregisterMiddleware`.
 
 ## Accessing the original (unmodified) state in a middleware
 
@@ -1158,7 +1156,7 @@ When executed, a middleware might accept a second argument which reflects the cu
 
 ## Defining settings for middlewares
 
-Some middlewares require additional configurations in order to work as expected. Above we've looked at a `customLogMiddleware` middleware, which console logs the newly created state. Now if we wanted to control the log type to let's say output to `console.debug` we can make use of middleware settings.
+Some middlewares require additional configurations in order to work as expected. Above we've looked at a `customLogMiddleware` middleware, which logs the newly created state to the console. Now if we wanted to control the log type to, let's say, output to `console.debug` we can make use of middleware settings.
 These are passed in as the third argument to the middleware function and are registered with `registerMiddlware`.
 
 <code-listing heading="Passing settings to middlewares">
@@ -1182,10 +1180,10 @@ These are passed in as the third argument to the middleware function and are reg
   </source-code>
 </code-listing>
 
-## Calling action reference for middlewares
+## Reference to the calling action for middlewares
 
-Last but not least the optional forth argument passed into a middleware is the calling action, meaning the action that is dispatched.
-In here you get an object containing the actions `name` and the provided `params`. This is useful when you, for instance, want only certain actions to pass or be canceled under certain circumstances. 
+Last but not least the optional forth argument passed into a middleware is the calling action, meaning the action that is being dispatched.
+In here you get an object containing the action's `name` and the provided `params`. This is useful when you, for instance, want only certain actions to pass or be canceled under certain circumstances. 
 
 <code-listing heading="Reference to the calling action in middlewares">
   <source-code lang="TypeScript">
@@ -1218,7 +1216,7 @@ In here you get an object containing the actions `name` and the provided `params
 
 ## Error propagation with middlewares
 
-By default errors thrown by middlewares will be swallowed in order to guarantee continues states. If you would like to stop state propagation you need to pass in the `propagateError` option set to `true`:
+By default errors thrown by middlewares will be swallowed in order to guarantee continued states. If you would like to stop state propagation you need to set the `propagateError` option of the plugin to `true`:
 
 <code-listing heading="Registering the plugin with active error propagation">
   <source-code lang="TypeScript">
@@ -1272,7 +1270,7 @@ Aurelia Store comes with a few home-baked middlewares. Others should be added as
 
 ### The Logging Middleware
 
-From the previous explanations of the inner workings of middlewares, you've come to learn about the loggingMiddlware. Instead of rebuilding it you can simply import it from Aurelia Store and register it. Remember that you can pass in a settings object to define the logType, which is also defined as string enum in typescript.
+From the previous explanations of the inner workings of middlewares, you've come to learn about the `loggingMiddleware`. Instead of rebuilding it you can simply import it from Aurelia Store and register it. Remember that you can pass in a settings object to define the `logType`, which is also defined as a string enum in TypeScript.
 
 <code-listing heading="Registering the Logging middleware">
   <source-code lang="TypeScript">
@@ -1300,9 +1298,9 @@ From the previous explanations of the inner workings of middlewares, you've come
 
 ### The Local Storage middleware
 
-The `localStorageMiddleware` stores your most recent emitted state in the [window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). This is useful when creating apps which should survive a full page refresh. Generally, it makes the most sense to place the middleware at the end of the queue to get the latest available value stored in localStorage.
+The `localStorageMiddleware` stores your most recent emitted state in the [window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage). This is useful when creating apps which should survive a full page refresh. Generally, it makes the most sense to place the middleware at the end of the queue to get the latest available value stored in `localStorage`.
 
-In order to make use of it all, you need to do is to register it as usual. By default, the storage key will be `aurelia-store-state`. You can additionally provide a storage-key via the settings to be used instead.
+In order to make use of it all, all you need to do is to register the middleware as usual. By default, the storage key will be `aurelia-store-state`. You can additionally provide a storage-key via the settings to be used instead.
 
 <code-listing heading="Registering the LocalStorage middleware">
   <source-code lang="TypeScript">
@@ -1354,13 +1352,13 @@ Now in order to rehydrate the stored state, all you need to do is to dispatch th
   </source-code>
 </code-listing>
 
-> Keep in mind that the store starts with an initialState. If the localStorage middleware is registered at the apps start, most likely the next refresh, will immediately overwrite your localStorage and that way negate the effect of restoring data from previous runs. In order to avoid that make sure to register the middleware just after the initial state has passed.
+> Keep in mind that the store starts with an `initialState`. If the `localStorage` middleware is registered at the app's start, most likely the next refresh will immediately overwrite your `localStorage` and negate the effect of restoring data from previous runs. In order to avoid that, make sure to register the middleware just after the initial state has loaded.
 
 ## Execution order
 
-If multiple actions are dispatched, they will get queued and executed one after another in order to make sure that each dispatch starts with an up to date state.
+If multiple actions are dispatched, they will get queued and executed one after another in order to make sure that each dispatch starts with an up-to-date state.
 
-If either your actions or middlewares return a sync or async value of `false` it will cause the Aurelia Store plugin to interrupt the execution and not emit the next state. Use this behavior in order to avoid unnecessary states. 
+If either your actions or middlewares return a sync or async value of `false` it will cause the Aurelia Store plugin to interrupt the execution and not emit the next state. Use this behavior in order to avoid unnecessary state updates. 
 
 
 ## Tracking overall performance
@@ -1386,18 +1384,18 @@ In order to get insights into total run durations to effectively calculate how l
 
 You can choose between `startEnd` - which gets you a single measure with the duration of the whole dispatch queue - or `all`, which will log, besides the total duration, all single marks after every middleware and the actual dispatching.
 
-Measures will only be logged for successful next states, so if an action or middleware aborts due to returning `false` or throwing an error, nothing gets logged.
+Measures will only be logged for successful state updates, so if an action or middleware aborts due to returning `false` or throwing an error, nothing gets logged.
 
 ## Debugging with the Redux DevTools extension
 
-If you've ever worked with Redux then you know for sure about the [Redux Devtools browser extension](https://github.com/zalmoxisus/redux-devtools-extension). It's a fantastic way to record and replay the states of your applications walkthrough. For each step, you get detailed information about your state at that time. This can tremendously help to debug states and replicate issues more easily.
+If you've ever worked with Redux then you know for sure about the [Redux Devtools browser extension](https://github.com/zalmoxisus/redux-devtools-extension). It's a fantastic way to record and replay the states of your application's walkthrough. For each step, you get detailed information about your state at that time. This can help tremendously to debug states and replicate issues more easily.
 
 There are tons of [great articles](https://codeburst.io/redux-devtools-for-dummies-74566c597d7) to get you started. Head over to [DevTools browser extension page](https://github.com/zalmoxisus/redux-devtools-extension) for instructions on how to install the extension, start your Aurelia Store plugin project and see how it works.
 
 
 ## Defining custom LogLevels
 
-For various features, Aurelia store does create log statements if turned on. E.g the dispatch info of the currently dispatched action will log on info level by default. Combining multiple of those features might be very distracting in your console window. As such you can define the log level to be used per feature in the plugins setup options. In the following example, we'd like to have the `logLevel` for the dispatchAction info set to `debug` instead of the default `info` level.
+For various features, Aurelia Store can log information if logging is turned on. E.g. the dispatch info of the currently dispatched action will log on info level by default. Combining the logging of many of these features might be very distracting in your console window. As such you can define the log level to be used per feature in the plugin's setup options. In the following example, we'd like to have the `logLevel` for the `dispatchAction` info set to `debug` instead of the default `info` level.
 
 <code-listing heading="Dispatch logs to console.debug">
   <source-code lang="TypeScript">
@@ -1431,23 +1429,23 @@ Besides the control for `dispatchedActions` you can also set the logType for the
 ## Comparison to other state management libraries
 
 There are a lot of other state management libraries out there, so you might ask yourself why you should favor Aurelia Store instead. As always Aurelia doesn't want to force you into a certain direction. There are good reasons to stick with something you're already familiar or using in another project.
-Let's look at the differences with few of the well-known alternatives. 
+Let's look at the differences with a few of the well-known alternatives. 
 
 ### Differences to Redux
 
-Doubtlessly [Redux](https://redux.js.org/) is one of the most favorite state management libraries out there in the eco system. With its solid principles of being a predictable state container and thus working towards consistently behaving apps, it's a common choice amongst React developers. A lot of that is given by the focus of immutable states and the predictability that brings with itself. Yet Redux is not solely bound to a framework and can be used with everything else, [including Aurelia](https://www.sitepoint.com/managing-state-aurelia-with-redux/) as well. There are even plugins to help you [get started](https://github.com/steelsojka/aurelia-redux-plugin).
+Doubtlessly [Redux](https://redux.js.org/) is one of the most favored state management libraries out there in the ecosystem. With its solid principles of being a predictable state container and thus working towards consistently behaving apps, it's a common choice amongst React developers. A lot of that is motivated by the focus on immutable states and the predictability that this brings in itself. Yet Redux is not solely bound to React and can be used with everything else, [including Aurelia](https://www.sitepoint.com/managing-state-aurelia-with-redux/). There are even plugins to help you [get started](https://github.com/steelsojka/aurelia-redux-plugin).
 
-Aurelia Store shares a lot of fundamental design choices from Redux yet drastically differentiates in two points. For one it's the reduction of boilerplate code. There is no necessity to split Actions and Reducers, along with separate action constants. Plain functions are all that is needed. Secondly, handling async state calculations is simplified by treating the apps state as a stream of states. RxJS as such is a major differentiator, which slowly is also finding it's place in the [Redux eco-system](https://github.com/redux-observable/redux-observable).
+Aurelia Store shares a lot of fundamental design choices from Redux, yet drastically differentiates itself in two points. For one it's the reduction of boilerplate code. There is no necessity to split Actions and Reducers, along with separate action constants. Plain functions are all that is needed. Secondly, handling async state calculations is simplified by treating the apps state as a stream of states. RxJS as such is a major differentiator, which is also slowly finding its place in the [Redux eco-system](https://github.com/redux-observable/redux-observable).
 
 ### Differences to MobX
 
-[MobX](https://github.com/mobxjs/mobx) came up as a more lightweight alternative to Redux. With it's focus on observing properties for changes and that way manipulating the apps state, it addresses the issue of reducing boilerplate and not forcing the user into a strict functional programming style. MobX, same as Redux is not tied specifically to a framework - although they offer React bindings out of the box - yet it is not really a great fit for Aurelia. The primary reason for that is that observing property changes is actually one of the main selling points of Aurelia.
+[MobX](https://github.com/mobxjs/mobx) came up as a more lightweight alternative to Redux. With its focus on observing properties for changes and that way manipulating the app's state, it addresses the issue of reducing boilerplate and not forcing the user into a strict functional programming style. MobX, similar to Redux, is not tied specifically to a framework - although they offer React bindings out of the box - yet it is not really a great fit for Aurelia. The primary reason for this is that observing property changes is actually one of the main selling points of Aurelia.
 Same applies to computed values resembling Aurelia's `computedFrom` and reactions, being pretty much the same as `propertyChanged` handlers.
 
-Essentially all that MobX brings to the table, might be implemented with vanilla Aurelia plus a global state service.
+Essentially all that MobX brings to the table might be implemented with vanilla Aurelia plus a global state service.
 
 ### Differences to VueX
 
-The last well-known alternative is [VueX](https://github.com/vuejs/vuex), state management library designed specifically for use with the [Vue framework](https://vuejs.org/v2/guide/). On the surface, VueX is relatively similar to MobX with some specific twists to how it handles internal changes, being `mutations`, although developers [seem to disagree](https://twitter.com/youyuxi/status/736939734900047874?lang=de) about that. Mutations very much translate function wise to Redux reducers, with the difference that they make use of Vue's change tracking and thus nicely fit into the framework itself. Modules, on the other hand, are another way to group your actions.
+The last well-known alternative is [VueX](https://github.com/vuejs/vuex), a state management library designed specifically for use with the [Vue framework](https://vuejs.org/v2/guide/). On the surface, VueX is relatively similar to MobX with some specific twists to how it handles internal changes, being `mutations`, although developers [seem to disagree](https://twitter.com/youyuxi/status/736939734900047874?lang=de) about that. Mutations very much translate function-wise to Redux reducers, with the difference that they make use of Vue's change tracking and thus nicely fit into the framework itself. Modules, on the other hand, are another way to group your actions.
 
-Aurelia Store in that regards is pretty similar to VueX. It makes use of Aurelia's dependency injection, logging and platform abstractions, but aside from that is still a plain simple TypeScript class and could be re-used for any other purpose. One of the biggest differentiators is that Aurelia Store does not force any specific style. Whether you prefer a class-based approach, using the `connectTo` decorator, or heavy function based composition, the underlying architecture of a private BehaviorSubject and a public Observable is flexible enough to adapt to your needs.
+Aurelia Store is pretty similar to VueX in that regard. It makes use of Aurelia's dependency injection, logging and platform abstractions, but aside from that is still a plain simple TypeScript class and could be re-used for any other purpose. One of the biggest differentiators is that Aurelia Store does not force any specific style. Whether you prefer a class-based approach, using the `connectTo` decorator, or heavy function based composition, the underlying architecture of a private `BehaviorSubject` and a public `Observable` is flexible enough to adapt to your needs.


### PR DESCRIPTION
I read through the entire doc and made small alterations that I think improve the readability somewhat.

There were a few things I wanted to discuss before I changed them out of hand:

> Since having access to the BehaviorSubject would allow consumers to directly emit the `next` value, instead of a front-facing `state` property, being an Observable which connects to the BehaviorSubject, is exposed.

I was unable to parse this sentence, and I don't know enough about RxJS to guess what was meant.

> Whether you prefer TypeScript or pure JavaScript is up to you, but having a typed state, allows for easier refactoring and better autocompletion support.

I modified this sentence slightly, but I wonder whether the remark should be part of this documentation at all.

> You're not forced to use async/await but it's highly recommended to use it for better readability wherever you can

Similar to the above.

> This is done in your app's `main` file, specifically the `configure` method.

Perhaps this should link to [App Configuration and Startup](https://aurelia.io/docs/fundamentals/app-configuration-and-startup)?
