### PR TITLE
doc(history): Remove superfluous newState object

### DIFF
--- a/doc/article/en-US/aurelia-store-plugin.md
+++ b/doc/article/en-US/aurelia-store-plugin.md
@@ -901,9 +901,6 @@ You can use the `nextStateHistory` helper function to easily push your new state
     import { State } from "./state";
 
     const demoAction = (currentState: StateHistory<State>, frameworkName: string) => {
-      const newState = Object.assign({}, state);
-      newState.frameworks = [...newState.frameworks, frameworkName];
-
       return nextStateHistory(currentState, {
         frameworks: [...frameworks, frameworkName]
       });
@@ -929,9 +926,6 @@ You can use the `nextStateHistory` helper function to easily push your new state
     import { nextStateHistory, StateHistory } from "aurelia-store";
 
     const demoAction = (currentState, frameworkName) => {
-      const newState = Object.assign({}, state);
-      newState.frameworks = [...newState.frameworks, frameworkName];
-
       return nextStateHistory(currentState, {
         frameworks: [...frameworks, frameworkName]
       });


### PR DESCRIPTION
It seems as though `newState` was included as a copy and paste error.