### PR TITLE
Multiple Selectors Feature

### DIFF
--- a/doc/article/en-US/aurelia-store-plugin.md
+++ b/doc/article/en-US/aurelia-store-plugin.md
@@ -369,6 +369,48 @@ If you want to have multiple selectors, you can pass an object to the `selector`
   </source-code>
 </code-listing>
 
+You can still provide a `target` with multiple selectors, which changes the behavior of multiple selectors. Instead of having multiple target properties on your view model for each selector name, the `target` will be an object on your view model and the multiple selector names will be the properties on that object. 
+
+<code-listing heading="Defining multiple selectors with a target">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>({
+      target: 'currentState',
+      selector: {
+        frameworks: (store) => store.state.pluck("frameworks"),
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      activate() {
+        console.log(this.currentState.frameworks);
+        console.log(this.currentState.databases);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo({
+      target: 'currentState',
+      selector: {
+        currentState: (store) => store.state.pluck("frameworks"), // same as above
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      activate() {
+        console.log(this.currentState.frameworks);
+        console.log(this.currentState.databases);
+      }
+    }
+  </source-code>
+</code-listing>
 
 Not only the target but also the default `setup` and `teardown` methods can be specified, either one or both. The hooks `bind` and `unbind` act as the default value.
 
@@ -407,6 +449,195 @@ Not only the target but also the default `setup` and `teardown` methods can be s
 > Info
 > The provided action names for setup and teardown don't necessarily have to be one of the official [lifecycle methods](http://aurelia.io/docs/fundamentals/components#the-component-lifecycle) but should be used as these get called automatically by Aurelia at the proper time.
 
+Last but not least you can also handle changes from the state in multiple ways
+
+The decorator will attempt to call `stateChanged(newState, oldState)` when no settings are passed, a function is used or an object settings is used with selector.
+
+<code-listing heading="Default change stateChanged handling">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    // All of these have the same change handling
+    // @connectTo<State>({
+    //   selector: (store) => store.state.pluck("frameworks"),
+    // })
+    // OR
+    // @connectTo<State>((store) => store.state.pluck("frameworks"))
+    // OR
+    @connectTo<State>()
+    export class App {
+      ...
+
+      stateChanged(newState: State, oldState: State) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    // All of these have the same change handling
+    // @connectTo({
+    //   selector: (store) => store.state.pluck("frameworks"),
+    // })
+    // OR
+    // @connectTo((store) => store.state.pluck("frameworks"))
+    // OR
+    @connectTo()
+    export class App {
+      ...
+
+      stateChanged(newState, oldState) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+</code-listing>
+
+Providing a target name without multiple selectors calls the`target`Changed method instead.
+
+<code-listing heading="Default change handling with target">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>({
+      target: "currentState"
+    })
+    export class App {
+      ...
+
+      currentStateChanged(newState: State, oldState: State) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo({
+      target: "currentState"
+    })
+    export class App {
+      ...
+
+      currentStateChanged(newState, oldState) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+</code-listing>
+
+With multiple selectors, you get the same change handling per selector.
+
+<code-listing heading="Default change handling with multiple selectors">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>({
+      selector: {
+        frameworks: (store) => store.state.pluck("frameworks"),
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+
+      frameworksChanged(newState: State, oldState: State) {
+        console.log("The state has changed", newState);
+      }
+
+      databasesChanged(newState: State, oldState: State) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo({
+      selector: {
+        frameworks: (store) => store.state.pluck("frameworks"),
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+
+      frameworksChanged(newState, oldState) {
+        console.log("The state has changed", newState);
+      }
+
+      databasesChanged(newState, oldState) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+</code-listing>
+
+However, providing a `target` with multiple selectors changes the prior behavior by calling the `target`Changed method with 3 arguments instead of each individual selector with 2 arguments. You get access to individual state being changed from the first argument.
+
+<code-listing heading="Default change handling with multiple selectors and target">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>({
+      target: "currentState",
+      selector: {
+        frameworks: (store) => store.state.pluck("frameworks"),
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+
+      currentStateChanged(stateName: string, newState: State, oldState: State) {
+        // this will be called twice:
+        //   once for stateName="frameworks"
+        //   once for stateName="databases"
+
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo({
+      target: "currentState",
+      selector: {
+        frameworks: (store) => store.state.pluck("frameworks"),
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+
+      currentStateChanged(stateName, newState, oldState) {
+        // this will be called twice:
+        //   once for stateName="frameworks"
+        //   once for stateName="databases"
+
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+</code-listing>
 
 Last but not least you can also define a callback to be called with the next state once a state change happens.
 
@@ -417,14 +648,14 @@ Last but not least you can also define a callback to be called with the next sta
     ...
 
     @connectTo<State>({
-      selector: (store) => store.state.pluck("frameworks"), // same as above
-      onChanged: "stateChanged"
+      selector: (store) => store.state.pluck("frameworks"),
+      onChanged: "changeHandler"
     })
     export class App {
       ...
 
-      stateChanged(state: State) {
-        console.log("The state has changed", state);
+      changeHandler(newState: State, oldState: State) {
+        console.log("The state has changed", newState);
       }
     }
   </source-code>
@@ -435,20 +666,56 @@ Last but not least you can also define a callback to be called with the next sta
 
     @connectTo({
       selector: (store) => store.state.pluck("frameworks"), // same as above
-      onChanged: "stateChanged"
+      onChanged: "changeHandler"
     })
     export class App {
       ...
 
-      stateChanged(state) {
-        console.log("The state has changed", state);
+      changeHandler(newState, oldState) {
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+</code-listing>
+
+For any one of these configuration, you can add an additional change handling function called `propertyChanged` that will be called last. This has 3 arguments, the state name being changed, the new state and the old state.
+
+<code-listing heading="Default change handling with propertyChanged">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>()
+    export class App {
+      ...
+
+      propertyChanged(stateName: string, newState: State, oldState: State) {
+        // stateName will be "state"
+        console.log("The state has changed", newState);
+      }
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo()
+    export class App {
+      ...
+
+      propertyChanged(stateName, newState, oldState) {
+        // stateName will be "state"
+        console.log("The state has changed", newState);
       }
     }
   </source-code>
 </code-listing>
 
 > Info
-> Your `onChanged` handler will be called before the target property is changed. This way you have access to both the current and previous state.
+> Your change handler function will be called before the target property is changed. This way you have access to both the current and previous state.
+> If you provide an `onChanged` handler, then you could have up to 3 change handling methods in your view model (called in order): the `onChanged` method, the `target`Changed method and the `propertyChanged` method.
 
 Next, let's find out how to produce state changes.
 

--- a/doc/article/en-US/aurelia-store-plugin.md
+++ b/doc/article/en-US/aurelia-store-plugin.md
@@ -334,6 +334,41 @@ If you need more control and for instance want to override the default target pr
   </source-code>
 </code-listing>
 
+If you want to have multiple selectors, you can pass an object to the `selector`, where each property in that `selector` object defines the new `target` receiving the state and the value is the function matching above.
+
+<code-listing heading="Defining multiple selectors">
+  <source-code lang="TypeScript">
+
+    // app.ts
+    ...
+
+    @connectTo<State>({
+      selector: {
+        currentState: (store) => store.state.pluck("frameworks"), // same as above
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+    }
+  </source-code>
+  <source-code lang="JavaScript">
+
+    // app.js
+    ...
+
+    @connectTo({
+      selector: {
+        currentState: (store) => store.state.pluck("frameworks"), // same as above
+        databases: (store) => store.state.pluck("databases")
+      }
+    })
+    export class App {
+      ...
+    }
+  </source-code>
+</code-listing>
+
 
 Not only the target but also the default `setup` and `teardown` methods can be specified, either one or both. The hooks `bind` and `unbind` act as the default value.
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -5,31 +5,46 @@ import { Store } from "./store";
 
 export interface ConnectToSettings<T, R = T | any> {
   onChanged?: string;
-  selector: ((store: Store<T>) => Observable<R>);
+  selector: ((store: Store<T>) => Observable<R>) | MultipleSelector<T, R>;
   setup?: string;
   target?: string;
   teardown?: string;
 }
 
+export interface MultipleSelector<T, R = T | any> {
+  [key: string]: ((store: Store<T>) => Observable<R>);
+}
+
+interface MultipleSelected {
+  [key: string]: Observable<any>;
+}
+
 export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observable<R>) | ConnectToSettings<T, R>) {
   const store = Container.instance.get(Store) as Store<T>;
 
-  function getSource(): Observable<any> {
+  function getSources(): MultipleSelected {
+    const targetName = (settings && (settings as ConnectToSettings<T, R>).target) || "";
+
     if (typeof settings === "function") {
       const selector = settings(store);
 
       if (selector instanceof Observable) {
-        return selector;
+        return { [targetName]: selector };
       }
     } else if (settings && typeof settings.selector === "function") {
       const selector = settings.selector(store);
 
       if (selector instanceof Observable) {
-        return selector;
+        return { [targetName]: selector };
       }
+    } else if (settings && Object.keys(settings.selector).length) {
+      return Object.entries(settings.selector).reduce((accu, curr) => ({
+        ...accu,
+        [curr[0]]: curr[1](store)
+      }), { });
     }
 
-    return store.state;
+    return { [targetName]: store.state };
   }
 
   return function (target: any) {
@@ -41,27 +56,37 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       : target.prototype.unbind;
 
     target.prototype[typeof settings === "object" && settings.setup ? settings.setup : "bind"] = function () {
-      const source = getSource();
-
       if (typeof settings == "object" &&
         typeof settings.onChanged === "string" &&
         !(settings.onChanged in this)) {
         throw new Error("Provided onChanged handler does not exist on target VM");
       }
 
-      this._stateSubscription = source.subscribe(state => {
+      this._stateSubscriptions = Object.entries(getSources()).map(entry => entry[1].subscribe((state: any) => {
+        const targetName = entry[0];
+        const target = this[targetName] || this.state;
+
         // call onChanged first so that the handler has also access to the previous state
+        const changeHandler = `${targetName}Changed`;
+
+        // like the @observable decorator
+        if (changeHandler in this) {
+          this[changeHandler](state, target);
+        } else if ("propertyChanged" in this) {
+          this.propertyChanged(targetName, state, target);
+        }
+
         if (typeof settings == "object" &&
           typeof settings.onChanged === "string") {
           this[settings.onChanged](state);
         }
 
-        if (typeof settings === "object" && settings.target) {
-          this[settings.target] = state;
+        if (targetName) {
+          this[targetName] = state;
         } else {
           this.state = state;
         }
-      });
+      }));
 
       if (originalSetup) {
         return originalSetup.apply(this, arguments);
@@ -69,10 +94,12 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
     }
 
     target.prototype[typeof settings === "object" && settings.teardown ? settings.teardown : "unbind"] = function () {
-      if (this._stateSubscription &&
-        this._stateSubscription instanceof Subscription &&
-        (this._stateSubscription as Subscription).closed === false) {
-        this._stateSubscription.unsubscribe();
+      if (this._stateSubscriptions && Array.isArray(this._stateSubscriptions)) {
+        this._stateSubscriptions.forEach((sub: Subscription) => {
+          if (sub instanceof Subscription && sub.closed === false) {
+            sub.unsubscribe();
+          }
+        });
       }
 
       if (originalTeardown) {

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -15,14 +15,10 @@ export interface MultipleSelector<T, R = T | any> {
   [key: string]: ((store: Store<T>) => Observable<R>);
 }
 
-interface MultipleSelected {
-  [key: string]: Observable<any>;
-}
-
 export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observable<R>) | ConnectToSettings<T, R>) {
   const store = Container.instance.get(Store) as Store<T>;
 
-  function getSources(): MultipleSelected {
+  function getSources() {
     const targetName = (settings && (settings as ConnectToSettings<T, R>).target) || "";
 
     if (typeof settings === "function") {
@@ -41,7 +37,7 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       return Object.entries(settings.selector).reduce((accu, curr) => ({
         ...accu,
         [curr[0]]: curr[1](store)
-      }), { });
+      }), {});
     }
 
     return { [targetName]: store.state };
@@ -62,7 +58,7 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
         throw new Error("Provided onChanged handler does not exist on target VM");
       }
 
-      this._stateSubscriptions = Object.entries(getSources()).map(entry => entry[1].subscribe((state: any) => {
+      this._stateSubscriptions = Object.entries(getSources()).map(entry => entry[1].subscribe((state: R) => {
         const targetName = entry[0];
         const target = this[targetName] || this.state;
 

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -48,8 +48,8 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       // numbers are the starting index to slice all the change handling args, 
       // which are prop name, new state and old state
       changeHandlers: {
-        [`${_settings.target || target}Changed`]: _settings.target ? 0 : 1,
         [_settings.onChanged || ""]: 1,
+        [`${_settings.target || target}Changed`]: _settings.target ? 0 : 1,
         ["propertyChanged"]: 0
       }
     }));

--- a/test/unit/decorator.spec.ts
+++ b/test/unit/decorator.spec.ts
@@ -72,7 +72,7 @@ describe("using decorators", () => {
       expect(sut.state).toEqual(initialState.bar);
     });
 
-    it("should be possible to provide an object with many selectors", () => {
+    it("should be possible to provide an object with multiple selectors", () => {
       const { store, initialState } = arrange();
 
       @connectTo<DemoState>({
@@ -83,6 +83,8 @@ describe("using decorators", () => {
       })
       class DemoStoreConsumer {
         state: DemoState;
+        barTarget: string;
+        fooTarget: string;
       }
 
       const sut = new DemoStoreConsumer();
@@ -429,7 +431,7 @@ describe("using decorators", () => {
       (sut as any).bind();
     });
 
-    it("should call targetChanged handler when exists on the VM with the new and old state", () => {
+    it("should call the targetChanged handler on the VM, if existing, with the new and old state", () => {
       const { store, initialState } = arrange();
        let targetValOnChange = null;
 
@@ -456,7 +458,7 @@ describe("using decorators", () => {
       expect(sut.targetPropChanged).toHaveBeenCalledWith(initialState, "foobar");
     });
 
-    it("should call propertyChanged handler when exists on the VM with the new and old state", () => {
+    it("should call the propertyChanged handler on the VM, if existing, with the new and old state", () => {
       const { store, initialState } = arrange();
       let targetValOnChange = null;
 


### PR DESCRIPTION
Support an additional `selector` setup for a `selector` object whose property names will be the target names on the view model and that property value will be the result of the function that selects the value from the store.

I thought it would be easier in the decorator to make `getSources` return an object with the target name as the property name and the result of the selector function (the Observable) as the value so the code in `subscribe` deals with an object regardless of the selector that was originally in the `settings`. Then, the `onChange` handling code can be left in the `subscribe` handler since the target name and Observable are both accessible. To get around no target names, you will see i set the `targetName` to a blank string in `getSouces`  since `subscribe` will check if there is a target, and if no target, sets the `state` property on the view model.