### PR TITLE
feat(devtools): Add action params to the devtools Action view

### DIFF
--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -1,5 +1,6 @@
 export interface Action<T = any> {
   type: T;
+  params: any[];
 }
 
 export interface ActionCreator<T> {

--- a/src/store.ts
+++ b/src/store.ts
@@ -144,17 +144,20 @@ export class Store<T> {
     }
     PLATFORM.performance.mark("dispatch-start");
 
-    const action = this.actions.get(reducer);
+    const action = {
+      type: this.actions.get(reducer)!.type,
+      params
+    };
 
     if (this.options.logDispatchedActions) {
-      this.logger[getLogType(this.options, "dispatchedActions", LogLevel.info)](`Dispatching: ${action!.type}`);
+      this.logger[getLogType(this.options, "dispatchedActions", LogLevel.info)](`Dispatching: ${action.type}`);
     }
 
     const beforeMiddleswaresResult = await this.executeMiddlewares(
       this._state.getValue(),
       MiddlewarePlacement.Before,
       {
-        name: action!.type,
+        name: action.type,
         params
       }
     );
@@ -173,7 +176,7 @@ export class Store<T> {
 
       return;
     }
-    PLATFORM.performance.mark("dispatch-after-reducer-" + action!.type);
+    PLATFORM.performance.mark("dispatch-after-reducer-" + action.type);
 
     if (!result && typeof result !== "object") {
       throw new Error("The reducer has to return a new state");
@@ -183,7 +186,7 @@ export class Store<T> {
       result,
       MiddlewarePlacement.After,
       {
-        name: action!.type,
+        name: action.type,
         params
       }
     );
@@ -213,14 +216,14 @@ export class Store<T> {
 
       const measures = PLATFORM.performance.getEntriesByName("startEndDispatchDuration");
       this.logger[getLogType(this.options, "performanceLog", LogLevel.info)](
-        `Total duration ${measures[0].duration} of dispatched action ${action!.type}:`,
+        `Total duration ${measures[0].duration} of dispatched action ${action.type}:`,
         measures
       );
     } else if (this.options.measurePerformance === PerformanceMeasurement.All) {
       const marks = PLATFORM.performance.getEntriesByType("mark");
       const totalDuration = marks[marks.length - 1].startTime - marks[0].startTime;
       this.logger[getLogType(this.options, "performanceLog", LogLevel.info)](
-        `Total duration ${totalDuration} of dispatched action ${action!.type}:`,
+        `Total duration ${totalDuration} of dispatched action ${action.type}:`,
         marks
       );
     }
@@ -228,7 +231,7 @@ export class Store<T> {
     PLATFORM.performance.clearMarks();
     PLATFORM.performance.clearMeasures();
 
-    this.updateDevToolsState(action!, resultingState);
+    this.updateDevToolsState(action, resultingState);
   }
 
   private executeMiddlewares(state: T, placement: MiddlewarePlacement, action: CallingAction): T | false {

--- a/src/store.ts
+++ b/src/store.ts
@@ -145,7 +145,7 @@ export class Store<T> {
     PLATFORM.performance.mark("dispatch-start");
 
     const action = {
-      type: this.actions.get(reducer)!.type,
+      ...this.actions.get(reducer)!,
       params
     };
 


### PR DESCRIPTION
Originally, only the `type` property was sent to the dev tools. This
commit adds the `params` to the private action object so the type and
the params are shown on the Action view in the devtools. IMPORTANT: anything that is
not serializable (aka a function) and is dispatched as a param will
show as a `null` value.

closes #75