### PR TITLE
refactor(decorator): delay store resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "aurelia-store",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -702,9 +702,10 @@
       }
     },
     "aurelia-framework": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.3.0.tgz",
-      "integrity": "sha512-yuKdy3LQx0tN/2CMKM8KTBcVLCeAcmcjXyEgWmRUlxJHCBAIT63ECrjkRWYkUzRNz8EQ0qnuH4jLUaWykXgJwg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.3.1.tgz",
+      "integrity": "sha512-eKR+JnrVzYQ372pokHjfw+YfiGpFIO6yGOotGHkeLtIVZcVowX4oYe1HEkDe7/VXU3f6cDILoYkNIwrZUBij0g==",
+      "dev": true,
       "requires": {
         "aurelia-binding": "^2.0.0",
         "aurelia-dependency-injection": "^1.0.0",
@@ -859,9 +860,9 @@
       }
     },
     "aurelia-templating": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.8.2.tgz",
-      "integrity": "sha512-5suUaJzEhxfJ8yVhOysWJHRwZW54ZaNumAIGqu6Jtnx/5h/08s9aZw1Ev1PMS3lYyq/w4KucdXbG8NeXnJBUNA==",
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.10.1.tgz",
+      "integrity": "sha512-GDClZWk+32SUYMsEttRFE3+dIbzZeDf5vl9dvuO6ULe+erTUOq2TUf9pHknWZuzoXXdGSD2qQnk+AEZZWW3MOQ==",
       "requires": {
         "aurelia-binding": "^2.0.0",
         "aurelia-dependency-injection": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -93,9 +93,9 @@
   },
   "dependencies": {
     "aurelia-dependency-injection": "^1.4.1",
-    "aurelia-framework": "^1.3.0",
     "aurelia-logging": "^1.5.0",
     "aurelia-pal": "^1.8.0",
+    "aurelia-templating": "^1.10.1",
     "rxjs": "^6.2.2"
   },
   "devDependencies": {
@@ -104,6 +104,7 @@
     "@types/rimraf": "^2.0.2",
     "@types/yargs": "^12.0.1",
     "aurelia-bootstrapper": "^2.3.0",
+    "aurelia-framework": "^1.3.1",
     "aurelia-loader-nodejs": "^1.0.1",
     "aurelia-pal-browser": "^1.8.0",
     "aurelia-pal-nodejs": "^1.2.0",

--- a/src/aurelia-store.ts
+++ b/src/aurelia-store.ts
@@ -1,6 +1,10 @@
-import { FrameworkConfiguration } from "aurelia-framework";
 import { Store, StoreOptions } from "./store";
 import { isStateHistory } from "./history";
+import { Container } from "aurelia-dependency-injection";
+
+export interface FrameworkConfiguration {
+  container: Container;
+}
 
 export interface StorePluginOptions<T> extends StoreOptions {
   initialState: T;

--- a/src/decorator.ts
+++ b/src/decorator.ts
@@ -78,7 +78,7 @@ export function connectTo<T, R = any>(settings?: ((store: Store<T>) => Observabl
       : target.prototype.unbind;
 
     // only override if prototype callback is a function
-    if (typeof originalCreated === "function") {
+    if (typeof originalCreated === "function" || originalCreated === undefined) {
       target.prototype.created = function created(_: View, view: View) {
         // here we relies on the fact that the class Store
         // has not been registered somewhere in one of child containers, instead of root container


### PR DESCRIPTION
This PR introduces the delay resolution for root store in decorator `@connectTo`, so it won't throw on too early usage of this decorator. This typically happens in test environment where a partial application is started without going through proper setup of global container.

Though there is still some potential improvement to make the decorator works nicely with multiple app scenario: get root container in `created` lifecycle and resolve store, store locally on the Aurelia instance, or root container instance instead of a statically declared store in the closure.

cc @zewa666 @michaelw85