### PR TITLE
refactor(middleware): make middleware settings typesafe

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,18 +5,15 @@ export interface CallingAction {
   params?: any[];
 }
 
-export type Middleware<T> = (state: T, originalState?: T, settings?: any, action?: CallingAction) => T | Promise<T | undefined | false> | void | false;
+export type Middleware<T, S = any> = (state: T, originalState: T | undefined, settings: S, action?: CallingAction) => T | Promise<T | undefined | false> | void | false;
 export enum MiddlewarePlacement {
   Before = "before",
   After = "after"
 }
 
-export function logMiddleware<T>(state: T, _: T, settings?: any) {
-  if (settings && settings.logType && console.hasOwnProperty(settings.logType)) {
-    (console as any)[settings.logType]("New state: ", state);
-  } else {
-    console.log("New state: ", state);
-  }
+export function logMiddleware(state: unknown, _: unknown, settings?: { logType: "debug" | "error" | "info" | "log" | "trace" | "warn" }) {
+  const logType = settings && settings.logType && console.hasOwnProperty(settings.logType) ? settings.logType : "log";
+  console[logType]("New state: ", state);
 }
 
 export function localStorageMiddleware<T>(state: T, _: T, settings?: any) {

--- a/src/store.ts
+++ b/src/store.ts
@@ -50,7 +50,7 @@ export class Store<T> {
     const isUndoable = this.options.history && this.options.history.undoable === true;
     this._state = new BehaviorSubject<T>(initialState);
     this.state = this._state.asObservable();
-      
+
     if (!this.options.devToolsOptions || this.options.devToolsOptions.disable !== true) {
       this.setupDevTools();
     }
@@ -60,17 +60,19 @@ export class Store<T> {
     }
   }
 
-  public registerMiddleware(reducer: Middleware<T>, placement: MiddlewarePlacement, settings?: any) {
+  public registerMiddleware<S extends undefined>(reducer: Middleware<T, undefined>, placement: MiddlewarePlacement): void;
+  public registerMiddleware<S extends NonNullable<any>>(reducer: Middleware<T, S>, placement: MiddlewarePlacement, settings: S): void;
+  public registerMiddleware<S>(reducer: Middleware<T, S>, placement: MiddlewarePlacement, settings?: S) {
     this.middlewares.set(reducer, { placement, settings });
   }
 
-  public unregisterMiddleware(reducer: Middleware<T>) {
+  public unregisterMiddleware(reducer: Middleware<T, any>) {
     if (this.middlewares.has(reducer)) {
       this.middlewares.delete(reducer);
     }
   }
 
-  public isMiddlewareRegistered(middleware: Middleware<T>) {
+  public isMiddlewareRegistered(middleware: Middleware<T, any>) {
     return this.middlewares.has(middleware);
   }
 


### PR DESCRIPTION
On my quest to introduce a "piped dispatch", I got side tracked, and saw that middleware settings were not typesafe, so I made them so.

Before this change
```ts
function myMiddleware(newState: State, oldState?: State, settings?: { foo: string }) { ... }

store.registerMiddleware(myMiddleware, MiddlewarePlacement.After, { notFoo: 42 }); // bad!
```
would have been accepted.
But with this change, the build would fail, and make you fix the code to one of these:
```ts
store.registerMiddleware(myMiddleware, MiddlewarePlacement.After, { foo: "some string" });
store.registerMiddleware(myMiddleware, MiddlewarePlacement.After);
```
Bonus: as a middleware writer, you can now force settings to be passed, by just making them a non-optional parameter in your middleware:
```ts
function forcedSettingsMiddleware(newState: State, oldState: State | undefined, settings: { foo: string }) { ... }

store.registerMiddleware(forcedSettingsMiddleware, MiddlewarePlacement.After); // would now scream
store.registerMiddleware(forcedSettingsMiddleware, MiddlewarePlacement.After, { foo: "some string" }); // would work
```

Double bonus: ff you have at least a certain TypeScript version which fixed some inference behavior (I believe 3.3.0+?), you even can Ctrl+Space inside the settings to get auto-completion. But for just finding type mismatches, the current minimum TypeScript version 3.0.1 works just as well.
In short, this change should be **non-breaking**, but enhanced if a higher TypeScript version is used.
 
I hope you find this useful. If there is anything that needs to be improved or changed, please let me know :)

For implementation details, please see the commit messages.

PS: I tried to sign the CLA but the link in https://github.com/aurelia/store/blob/master/CONTRIBUTING.md points to a dead googledoc.