### PR TITLE
Piped dispatch (without dispatchify)

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,6 +3,10 @@ import { PLATFORM } from "aurelia-pal";
 export interface CallingAction {
   name: string;
   params?: any[];
+  pipedActions?: {
+    name: string;
+    params?: any[];
+  }[];
 }
 
 export type Middleware<T, S = any> = (state: T, originalState: T | undefined, settings: S, action?: CallingAction) => T | Promise<T | undefined | false> | void | false;

--- a/src/store.ts
+++ b/src/store.ts
@@ -287,14 +287,14 @@ export class Store<T> {
   }
 
   private registerHistoryMethods() {
-    this.registerAction("jump", jump as any as Reducer<T>);
+    this.registerAction("jump", jump as Reducer<T>);
   }
 }
 
 export function dispatchify<T, P extends any[]>(action: Reducer<T, P> | string) {
-  const store = Container.instance.get(Store);
+  const store: Store<T> = Container.instance.get(Store);
 
   return function (...params: P) {
-    return store.dispatch(action, ...params) as Promise<void>;
+    return store.dispatch(action, ...params);
   }
 }

--- a/test/unit/helpers.ts
+++ b/test/unit/helpers.ts
@@ -6,7 +6,8 @@ import {
 import { StateHistory } from "../../src/history";
 
 export type testState = {
-  foo: string
+  foo: string,
+  bar?: string;
 };
 
 export function createTestStore() {

--- a/test/unit/store.spec.ts
+++ b/test/unit/store.spec.ts
@@ -9,6 +9,10 @@ import {
 } from "./helpers";
 
 describe("store", () => {
+  const UNREGISTERED_ACTION_ERROR_PREFIX = "Tried to dispatch an unregistered action ";
+  const MINIMUM_ONE_PARAMETER_ERROR_PREFIX = "The reducer is expected to have one or more parameters";
+  const NOT_RETURNING_NEW_STATE_ERROR = "The reducer has to return a new state";
+
   it("should accept an initial state", done => {
     const { initialState, store } = createTestStore();
 
@@ -24,13 +28,13 @@ describe("store", () => {
       return Object.assign({}, currentState, { foo: param1 + param2 })
     };
 
-    expect((store.dispatch as any)(unregisteredAction)).rejects.toThrowError();
+    expect((store.dispatch as any)(unregisteredAction)).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "unregisteredAction");
   })
 
   it("should fail when dispatching non actions", async () => {
     const { store } = createTestStore();
 
-    expect(store.dispatch(undefined as any)).rejects.toThrowError();
+    expect(store.dispatch(undefined as any)).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "undefined");
   })
 
   it("should only accept reducers taking at least one parameter", () => {
@@ -39,7 +43,7 @@ describe("store", () => {
 
     expect(() => {
       store.registerAction("FakeAction", fakeAction as any);
-    }).toThrowError();
+    }).toThrowError(MINIMUM_ONE_PARAMETER_ERROR_PREFIX);
   });
 
   it("should force reducers to return a new state", async () => {
@@ -47,7 +51,7 @@ describe("store", () => {
     const fakeAction = (_: testState) => { };
 
     store.registerAction("FakeAction", fakeAction as any);
-    expect(store.dispatch(fakeAction as any)).rejects.toBeDefined();
+    expect(store.dispatch(fakeAction as any)).rejects.toThrowError(NOT_RETURNING_NEW_STATE_ERROR);
   });
 
   it("should also accept false and stop queue", async () => {
@@ -80,7 +84,7 @@ describe("store", () => {
     expect(store.dispatch(fakeAction)).resolves;
 
     store.unregisterAction(fakeAction);
-    expect(store.dispatch(fakeAction)).rejects.toThrowError();
+    expect(store.dispatch(fakeAction)).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "fakeAction");
   });
 
   it("should not try to unregister previously unregistered actions", async () => {
@@ -340,7 +344,7 @@ describe("store", () => {
         return Object.assign({}, currentState, { foo: param1 });
       };
 
-      expect(() => store.pipe(unregisteredAction, "foo")).toThrowError();
+      expect(() => store.pipe(unregisteredAction, "foo")).toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "unregisteredAction");
     });
 
     it("should fail when at least one action is unknown", async () => {
@@ -351,13 +355,13 @@ describe("store", () => {
 
       const pipedDispatch = store.pipe(fakeAction);
 
-      expect(() => pipedDispatch.pipe(unregisteredAction, "foo")).toThrowError();
+      expect(() => pipedDispatch.pipe(unregisteredAction, "foo")).toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "fakeAction");
     });
 
     it("should fail when dispatching non actions", async () => {
       const { store } = createTestStore();
 
-      expect(() => store.pipe(undefined as any)).toThrowError();
+      expect(() => store.pipe(undefined as any)).toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "undefined");
     });
 
     it("should fail when at least one action is no action", async () => {
@@ -367,7 +371,7 @@ describe("store", () => {
 
       const pipedDispatch = store.pipe(fakeAction);
 
-      expect(() => pipedDispatch.pipe(undefined as any)).toThrowError();
+      expect(() => pipedDispatch.pipe(undefined as any)).toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "fakeAction");
     });
 
     it("should force reducer to return a new state", async () => {
@@ -375,7 +379,7 @@ describe("store", () => {
       const fakeAction = (_: testState) => { };
 
       store.registerAction("FakeAction", fakeAction as any);
-      expect(store.pipe(fakeAction as any).dispatch()).rejects.toBeDefined();
+      expect(store.pipe(fakeAction as any).dispatch()).rejects.toThrowError(NOT_RETURNING_NEW_STATE_ERROR);
     });
 
     it("should force all reducers to return a new state", async () => {
@@ -385,7 +389,7 @@ describe("store", () => {
       store.registerAction("FakeActionOk", fakeActionOk);
       store.registerAction("FakeActionNok", fakeActionNok as any);
 
-      expect(store.pipe(fakeActionNok as any).pipe(fakeActionOk).dispatch()).rejects.toThrowError();
+      expect(store.pipe(fakeActionNok as any).pipe(fakeActionOk).dispatch()).rejects.toThrowError(NOT_RETURNING_NEW_STATE_ERROR);
     });
 
     it("should also accept false and stop queue", async () => {
@@ -465,8 +469,9 @@ describe("store", () => {
 
     it("should not accept an unregistered action name as pipe argument", () => {
       const { store } = createTestStore();
+      const unregisteredActionId = "UnregisteredAction";
 
-      expect(() => store.pipe("UnregisteredAction")).toThrowError();
+      expect(() => store.pipe(unregisteredActionId)).toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + unregisteredActionId);
     });
 
     it("should support promised actions", done => {

--- a/test/unit/store.spec.ts
+++ b/test/unit/store.spec.ts
@@ -627,4 +627,43 @@ describe("store", () => {
       expect(loggerSpy).toHaveBeenCalledWith(expect.any(String), expect.any(Array));
     });
   });
+
+  describe("internalDispatch", () => {
+    it("should throw an error when called with unregistered actions", () => {
+      const { store } = createTestStore();
+      const unregisteredAction = (currentState: testState, param1: string) => {
+        return Object.assign({}, currentState, { foo: param1 });
+      };
+
+      expect((store as any).internalDispatch([{ reducer: unregisteredAction, params: ["foo"] }])).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "unregisteredAction");
+    });
+
+    it("should throw an error when one action of multiple actions is unregistered", () => {
+      const { store } = createTestStore();
+      const registeredAction = (currentState: testState) => currentState;
+      const unregisteredAction = (currentState: testState) => currentState;
+      store.registerAction("RegisteredAction", registeredAction);
+
+
+      expect((store as any).internalDispatch([
+        { reducer: registeredAction, params: [] },
+        { reducer: unregisteredAction, params: [] }
+      ])).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "unregisteredAction");
+    });
+
+    it("should throw an error about the first of many unregistered actions", () => {
+      const { store } = createTestStore();
+      const registeredAction = (currentState: testState) => currentState;
+      const firstUnregisteredAction = (currentState: testState) => currentState;
+      const secondUnregisteredAction = (currentState: testState) => currentState;
+      store.registerAction("RegisteredAction", registeredAction);
+
+
+      expect((store as any).internalDispatch([
+        { reducer: registeredAction, params: [] },
+        { reducer: firstUnregisteredAction, params: [] },
+        { reducer: secondUnregisteredAction, params: [] }
+      ])).rejects.toThrowError(UNREGISTERED_ACTION_ERROR_PREFIX + "firstUnregisteredAction");
+    });
+  });
 });


### PR DESCRIPTION
This PR targets the issue #89, where I have proposed to introduce a "piped" form of `dispatch`.

Sorry for the wait, but I had unexpectedly busy weeks, and I underestimated a little, how much there was to refactor to make this work while retaining compatibility. `Dispatchify` for pipes would have been a whole other beast, thanks to the types wizardry necessary to do it well. So in the interest of time, I'd like to save `dispatchify` for another PR.

Special thanks to @zewa666, who put together the handy checklist in the issue, and had good answers to some questions I had. I hope my PR reflects them well enough.

Here is the summary of the changes:

**Breaking changes:**
none (hopefully)
The only behavioral change I made on purpose, is to verify if a reducer has been registered, right at the dispatch call, rather than letting it go into the queue first and checking it only there. This was done because it makes it more consistent with the `pipe` behavior, which I made throw when trying to pipe unregistered actions. This should have no effect on the documented behavior, but if somebody somehow depends on queuing an asynchronous dispatch and then registering the reducer while it is waiting for execution, it might break something. I'm sincerely hoping that nobody has actually done this though ;)

**Features:**
- `store.pipe(reducer, params)` has been added, and returns a `PipedDispatch` object, which allows to chain more pipes into itself, or to `dispatch` the aggregated action.
  Example:
  ```ts
  await store
    .pipe(actionA, "foo", 42)
    .pipe(actionB, "bar", 1337)
    .dispatch();
  ```
  `pipe()` accepts only registered reducers, and will otherwise throw an error.
  A piped dispatch will only trigger a single state transition.
  However, when using History, multiple steps may appear in the history, as the individual actions handle history transitions. Discussing this with @zewa666, we agreed it is better to not meddle with the history and leave full control to the consumer. I intend to open a follow-up issue with a proposed solution to this scenario.
- Each individual piped action is timed and logged (if settings say so), but only a single entry is pushed to the redux devtools (as only a single state transition takes place). The "type" of a piped action is the individual action names joined by `->`.
  e.g. the above example would log `actionA->actionB`
- Middlewares' `callingAction` parameter has been kept backward compatible: the action name is for piped actions the individual actions joined by the string `->` (same as devtools), and the joint parameters are can be found in the params array. An additional (optional) property `pipedActions` has been added, which contains the details about the individual piped actions and their parameters, in case the consumer is interested in them.
- When just a single reducer is piped, and dispatched, the behavior is identical to classic `dispatch`

**Internal changes:**
-The `internalDispatch` function has a different signature now (accepts an array instead of just a single reducer), which should only affect those who knowingly used privates as a workaround.
-Added some types and removed some unnecessary casts (for internal stuff).

-For more details, see the commits, the new unit tests, or just ask :)

**Known issues:**
There is no `dispatchify` for piped actions (yet), as mentioned above

Please let me know, if there are any issues with this PR, or if something is not clear. I'll gladly make any requested changes.