### PR TITLE
Make localStorageMiddleware settings typesafe

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,5 +1,7 @@
 import { PLATFORM } from "aurelia-pal";
 
+const DEFAULT_LOCAL_STORAGE_KEY = "aurelia-store-state";
+
 export interface CallingAction {
   name: string;
   params?: any[];
@@ -18,7 +20,7 @@ export function logMiddleware(state: unknown, _: unknown, settings?: { logType: 
 
 export function localStorageMiddleware(state: unknown, _: unknown, settings?: { key: string }) {
   if (PLATFORM.global.localStorage) {
-    const key = settings && settings.key || "aurelia-store-state";
+    const key = settings && settings.key || DEFAULT_LOCAL_STORAGE_KEY;
 
     PLATFORM.global.localStorage.setItem(key, JSON.stringify(state));
   }
@@ -29,7 +31,7 @@ export function rehydrateFromLocalStorage<T>(state: T, key?: string) {
     return state;
   }
 
-  const storedState = PLATFORM.global.localStorage.getItem(key || "aurelia-store-state");
+  const storedState = PLATFORM.global.localStorage.getItem(key || DEFAULT_LOCAL_STORAGE_KEY);
   if (!storedState) {
     return state;
   }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -35,7 +35,7 @@ export function rehydrateFromLocalStorage<T>(state: T, key?: string) {
   }
 
   try {
-    return JSON.parse(storedState!);
+    return JSON.parse(storedState);
   } catch (e) { }
 
   return state;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,6 +1,6 @@
 import { PLATFORM } from "aurelia-pal";
 
-const DEFAULT_LOCAL_STORAGE_KEY = "aurelia-store-state";
+export const DEFAULT_LOCAL_STORAGE_KEY = "aurelia-store-state";
 
 export interface CallingAction {
   name: string;

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -16,11 +16,9 @@ export function logMiddleware(state: unknown, _: unknown, settings?: { logType: 
   console[logType]("New state: ", state);
 }
 
-export function localStorageMiddleware<T>(state: T, _: T, settings?: any) {
+export function localStorageMiddleware(state: unknown, _: unknown, settings?: { key: string }) {
   if (PLATFORM.global.localStorage) {
-    const key = settings && settings.key && typeof settings.key === "string"
-      ? settings.key
-      : "aurelia-store-state";
+    const key = settings && settings.key || "aurelia-store-state";
 
     PLATFORM.global.localStorage.setItem(key, JSON.stringify(state));
   }


### PR DESCRIPTION
A follow-up to #90, where I forgot to give `localStorageMiddleware` the same treatment (making the settings typesafe).

See commit messages for details.